### PR TITLE
change custom field modified detection

### DIFF
--- a/src/Infrastructure/Model/Basic/Shopware6CustomFieldConfig.php
+++ b/src/Infrastructure/Model/Basic/Shopware6CustomFieldConfig.php
@@ -96,7 +96,10 @@ class Shopware6CustomFieldConfig extends AbstractShopware6CustomFieldConfig
         foreach ($this->options as &$currentOption) {
             if ($currentOption['value'] === $option['value']) {
                 $newLabel = array_merge($currentOption['label'], $option['label']);
-                if (!empty(array_diff_assoc($currentOption['label'], $newLabel))) {
+                if (
+                    !empty(array_diff_assoc($newLabel, $currentOption['label']))
+                    || !empty(array_diff_assoc($currentOption['label'], $newLabel))
+                ) {
                     $currentOption['label'] = $newLabel;
                     $this->modified = true;
                 }


### PR DESCRIPTION
Issue : 
when we add translations for another language to custom field, the changes are not sent to shopware 6.

Reason should be clearly visible in http://sandbox.onlinephpfunctions.com/code/af56acc931fa9e1eb2ffecf62b8f1a582a284a30
We need to check whether any content was removed but also whether it was added. 