### PR TITLE
Changed URI structure for Shopware 6.4.x support

### DIFF
--- a/src/Infrastructure/Connector/Action/Category/DeleteCategory.php
+++ b/src/Infrastructure/Connector/Action/Category/DeleteCategory.php
@@ -15,7 +15,7 @@ use Symfony\Component\HttpFoundation\Request as HttpRequest;
 
 class DeleteCategory extends AbstractAction
 {
-    private const URI = '/api/v2/category/%s';
+    private const URI = '/api/category/%s';
 
     private string $categoryId;
 

--- a/src/Infrastructure/Connector/Action/Category/GetCategory.php
+++ b/src/Infrastructure/Connector/Action/Category/GetCategory.php
@@ -16,7 +16,7 @@ use Symfony\Component\HttpFoundation\Request as HttpRequest;
 
 class GetCategory extends AbstractAction
 {
-    private const URI = '/api/v2/category/%s';
+    private const URI = '/api/category/%s';
 
     private string $categoryId;
 

--- a/src/Infrastructure/Connector/Action/Category/GetCategoryList.php
+++ b/src/Infrastructure/Connector/Action/Category/GetCategoryList.php
@@ -17,7 +17,7 @@ use Symfony\Component\HttpFoundation\Request as HttpRequest;
 
 class GetCategoryList extends AbstractAction
 {
-    private const URI = '/api/v2/category?%s';
+    private const URI = '/api/category?%s';
 
     private Shopware6QueryBuilder $query;
 

--- a/src/Infrastructure/Connector/Action/Category/PatchCategoryAction.php
+++ b/src/Infrastructure/Connector/Action/Category/PatchCategoryAction.php
@@ -16,7 +16,7 @@ use Symfony\Component\HttpFoundation\Request as HttpRequest;
 
 class PatchCategoryAction extends AbstractAction
 {
-    private const URI = '/api/v2/category/';
+    private const URI = '/api/category/';
 
     private Shopware6Category $category;
 

--- a/src/Infrastructure/Connector/Action/Category/PostCategoryAction.php
+++ b/src/Infrastructure/Connector/Action/Category/PostCategoryAction.php
@@ -16,7 +16,7 @@ use Symfony\Component\HttpFoundation\Request as HttpRequest;
 
 class PostCategoryAction extends AbstractAction
 {
-    private const URI = '/api/v2/category?%s';
+    private const URI = '/api/category?%s';
 
     private Shopware6Category $category;
 

--- a/src/Infrastructure/Connector/Action/Currency/GetCurrencyList.php
+++ b/src/Infrastructure/Connector/Action/Currency/GetCurrencyList.php
@@ -16,7 +16,7 @@ use Symfony\Component\HttpFoundation\Request as HttpRequest;
 
 class GetCurrencyList extends AbstractAction
 {
-    private const URI = '/api/v2/currency?%s';
+    private const URI = '/api/currency?%s';
 
     private Shopware6QueryBuilder $query;
 

--- a/src/Infrastructure/Connector/Action/Currency/PostCurrencyCreate.php
+++ b/src/Infrastructure/Connector/Action/Currency/PostCurrencyCreate.php
@@ -15,7 +15,7 @@ use Symfony\Component\HttpFoundation\Request as HttpRequest;
 
 class PostCurrencyCreate extends AbstractAction
 {
-    private const URI = '/api/v2/currency';
+    private const URI = '/api/currency';
 
     private string $iso;
 

--- a/src/Infrastructure/Connector/Action/CustomField/GetCustomField.php
+++ b/src/Infrastructure/Connector/Action/CustomField/GetCustomField.php
@@ -17,7 +17,7 @@ use Symfony\Component\HttpFoundation\Request as HttpRequest;
 
 class GetCustomField extends AbstractAction
 {
-    private const URI = '/api/v2/custom-field/%s';
+    private const URI = '/api/custom-field/%s';
 
     private string $customFieldId;
 

--- a/src/Infrastructure/Connector/Action/CustomField/GetCustomFieldList.php
+++ b/src/Infrastructure/Connector/Action/CustomField/GetCustomFieldList.php
@@ -18,7 +18,7 @@ use Symfony\Component\HttpFoundation\Request as HttpRequest;
 
 class GetCustomFieldList extends AbstractAction
 {
-    private const URI = '/api/v2/custom-field?%s';
+    private const URI = '/api/custom-field?%s';
 
     private Shopware6QueryBuilder $query;
 

--- a/src/Infrastructure/Connector/Action/CustomField/GetCustomFieldSetList.php
+++ b/src/Infrastructure/Connector/Action/CustomField/GetCustomFieldSetList.php
@@ -19,7 +19,7 @@ use Symfony\Component\HttpFoundation\Request as HttpRequest;
 
 class GetCustomFieldSetList extends AbstractAction
 {
-    private const URI = '/api/v2/custom-field-set?%s';
+    private const URI = '/api/custom-field-set?%s';
 
     private Shopware6QueryBuilder $query;
 

--- a/src/Infrastructure/Connector/Action/CustomField/PatchCustomFieldAction.php
+++ b/src/Infrastructure/Connector/Action/CustomField/PatchCustomFieldAction.php
@@ -16,7 +16,7 @@ use Symfony\Component\HttpFoundation\Request as HttpRequest;
 
 class PatchCustomFieldAction extends AbstractAction
 {
-    private const URI = '/api/v2/custom-field/';
+    private const URI = '/api/custom-field/';
 
     private AbstractShopware6CustomField $customField;
 

--- a/src/Infrastructure/Connector/Action/CustomField/PostCustomFieldAction.php
+++ b/src/Infrastructure/Connector/Action/CustomField/PostCustomFieldAction.php
@@ -18,7 +18,7 @@ use Symfony\Component\HttpFoundation\Request as HttpRequest;
 
 class PostCustomFieldAction extends AbstractAction
 {
-    private const URI = '/api/v2/custom-field?%s';
+    private const URI = '/api/custom-field?%s';
 
     private AbstractShopware6CustomField $customField;
 

--- a/src/Infrastructure/Connector/Action/CustomField/PostCustomFieldSetAction.php
+++ b/src/Infrastructure/Connector/Action/CustomField/PostCustomFieldSetAction.php
@@ -18,7 +18,7 @@ use Symfony\Component\HttpFoundation\Request as HttpRequest;
 
 class PostCustomFieldSetAction extends AbstractAction
 {
-    private const URI = '/api/v2/custom-field-set?%s';
+    private const URI = '/api/custom-field-set?%s';
 
     private AbstractShopware6CustomFieldSet $customFieldSet;
 

--- a/src/Infrastructure/Connector/Action/Language/GetLanguageList.php
+++ b/src/Infrastructure/Connector/Action/Language/GetLanguageList.php
@@ -17,7 +17,7 @@ use Symfony\Component\HttpFoundation\Request as HttpRequest;
 
 class GetLanguageList extends AbstractAction
 {
-    private const URI = '/api/v2/language?%s';
+    private const URI = '/api/language?%s';
 
     private Shopware6QueryBuilder $query;
 

--- a/src/Infrastructure/Connector/Action/Language/GetLocate.php
+++ b/src/Infrastructure/Connector/Action/Language/GetLocate.php
@@ -16,7 +16,7 @@ use Symfony\Component\HttpFoundation\Request as HttpRequest;
 
 class GetLocate extends AbstractAction
 {
-    private const URI = '/api/v2/locale/%s';
+    private const URI = '/api/locale/%s';
 
     private string $locateId;
 

--- a/src/Infrastructure/Connector/Action/Media/DeleteMedia.php
+++ b/src/Infrastructure/Connector/Action/Media/DeleteMedia.php
@@ -15,7 +15,7 @@ use Symfony\Component\HttpFoundation\Request as HttpRequest;
 
 class DeleteMedia extends AbstractAction
 {
-    private const URI = '/api/v2/media/%s';
+    private const URI = '/api/media/%s';
 
     private string $mediaId;
 

--- a/src/Infrastructure/Connector/Action/Media/GetMedia.php
+++ b/src/Infrastructure/Connector/Action/Media/GetMedia.php
@@ -16,7 +16,7 @@ use Symfony\Component\HttpFoundation\Request as HttpRequest;
 
 class GetMedia extends AbstractAction
 {
-    private const URI = '/api/v2/media/%s';
+    private const URI = '/api/media/%s';
 
     private string $mediaId;
 

--- a/src/Infrastructure/Connector/Action/Media/GetMediaDefaultFolderList.php
+++ b/src/Infrastructure/Connector/Action/Media/GetMediaDefaultFolderList.php
@@ -17,7 +17,7 @@ use Symfony\Component\HttpFoundation\Request as HttpRequest;
 
 class GetMediaDefaultFolderList extends AbstractAction
 {
-    private const URI = '/api/v2/media-default-folder?%s';
+    private const URI = '/api/media-default-folder?%s';
 
     private Shopware6QueryBuilder $query;
 

--- a/src/Infrastructure/Connector/Action/Media/PostCreateMediaAction.php
+++ b/src/Infrastructure/Connector/Action/Media/PostCreateMediaAction.php
@@ -16,7 +16,7 @@ use Symfony\Component\HttpFoundation\Request as HttpRequest;
 
 class PostCreateMediaAction extends AbstractAction
 {
-    private const URI = '/api/v2/media?%s';
+    private const URI = '/api/media?%s';
 
     private string $mediaFolderId;
 

--- a/src/Infrastructure/Connector/Action/Media/PostMediaFolder.php
+++ b/src/Infrastructure/Connector/Action/Media/PostMediaFolder.php
@@ -15,7 +15,7 @@ use Symfony\Component\HttpFoundation\Request as HttpRequest;
 
 class PostMediaFolder extends AbstractAction
 {
-    private const URI = '/api/v2/media-folder?%s';
+    private const URI = '/api/media-folder?%s';
     private string $mediaFolder;
 
     private bool $response;

--- a/src/Infrastructure/Connector/Action/Media/PostUploadFile.php
+++ b/src/Infrastructure/Connector/Action/Media/PostUploadFile.php
@@ -16,7 +16,7 @@ use Symfony\Component\HttpFoundation\Request as HttpRequest;
 
 class PostUploadFile extends AbstractAction
 {
-    private const URI = '/api/v2/_action/media/%s/upload?%s';
+    private const URI = '/api/_action/media/%s/upload?%s';
 
     private string $multimediaId;
 

--- a/src/Infrastructure/Connector/Action/Product/Category/DeleteProductCategory.php
+++ b/src/Infrastructure/Connector/Action/Product/Category/DeleteProductCategory.php
@@ -15,7 +15,7 @@ use Symfony\Component\HttpFoundation\Request as HttpRequest;
 
 class DeleteProductCategory extends AbstractAction
 {
-    private const URI = '/api/v2/product/%s/categories/%s';
+    private const URI = '/api/product/%s/categories/%s';
 
     private string $productId;
 

--- a/src/Infrastructure/Connector/Action/Product/Category/GetProductCategory.php
+++ b/src/Infrastructure/Connector/Action/Product/Category/GetProductCategory.php
@@ -16,7 +16,7 @@ use Symfony\Component\HttpFoundation\Request as HttpRequest;
 
 class GetProductCategory extends AbstractAction
 {
-    private const URI = '/api/v2/product/%s/categories';
+    private const URI = '/api/product/%s/categories';
 
     private string $productId;
 

--- a/src/Infrastructure/Connector/Action/Product/ConfiguratorSettings/GetConfiguratorSettings.php
+++ b/src/Infrastructure/Connector/Action/Product/ConfiguratorSettings/GetConfiguratorSettings.php
@@ -16,7 +16,7 @@ use Symfony\Component\HttpFoundation\Request as HttpRequest;
 
 class GetConfiguratorSettings extends AbstractAction
 {
-    private const URI = '/api/v2/product/%s/configurator-settings';
+    private const URI = '/api/product/%s/configurator-settings';
 
     private string $productId;
 

--- a/src/Infrastructure/Connector/Action/Product/GetProductList.php
+++ b/src/Infrastructure/Connector/Action/Product/GetProductList.php
@@ -18,7 +18,7 @@ use Symfony\Component\HttpFoundation\Request as HttpRequest;
 
 class GetProductList extends AbstractAction
 {
-    private const URI = '/api/v2/product?%s';
+    private const URI = '/api/product?%s';
 
     private Shopware6QueryBuilder $query;
 

--- a/src/Infrastructure/Connector/Action/Product/Media/DeleteProductMedia.php
+++ b/src/Infrastructure/Connector/Action/Product/Media/DeleteProductMedia.php
@@ -15,7 +15,7 @@ use Symfony\Component\HttpFoundation\Request as HttpRequest;
 
 class DeleteProductMedia extends AbstractAction
 {
-    private const URI = '/api/v2/product/%s/media/%s';
+    private const URI = '/api/product/%s/media/%s';
 
     private string $productId;
 

--- a/src/Infrastructure/Connector/Action/Product/Media/GetProductMedia.php
+++ b/src/Infrastructure/Connector/Action/Product/Media/GetProductMedia.php
@@ -16,7 +16,7 @@ use Symfony\Component\HttpFoundation\Request as HttpRequest;
 
 class GetProductMedia extends AbstractAction
 {
-    private const URI = '/api/v2/product/%s/media';
+    private const URI = '/api/product/%s/media';
 
     private string $productId;
 

--- a/src/Infrastructure/Connector/Action/Product/PatchProductAction.php
+++ b/src/Infrastructure/Connector/Action/Product/PatchProductAction.php
@@ -16,7 +16,7 @@ use Symfony\Component\HttpFoundation\Request as HttpRequest;
 
 class PatchProductAction extends AbstractAction
 {
-    private const URI = '/api/v2/product/';
+    private const URI = '/api/product/';
 
     private Shopware6Product $product;
 

--- a/src/Infrastructure/Connector/Action/Product/PostProductAction.php
+++ b/src/Infrastructure/Connector/Action/Product/PostProductAction.php
@@ -16,7 +16,7 @@ use Symfony\Component\HttpFoundation\Request as HttpRequest;
 
 class PostProductAction extends AbstractAction
 {
-    private const URI = '/api/v2/product?%s';
+    private const URI = '/api/product?%s';
 
     private Shopware6Product $product;
 

--- a/src/Infrastructure/Connector/Action/Product/Properties/DeleteProperties.php
+++ b/src/Infrastructure/Connector/Action/Product/Properties/DeleteProperties.php
@@ -15,7 +15,7 @@ use Symfony\Component\HttpFoundation\Request as HttpRequest;
 
 class DeleteProperties extends AbstractAction
 {
-    private const URI = '/api/v2/product/%s/properties/%s';
+    private const URI = '/api/product/%s/properties/%s';
 
     private string $productId;
 

--- a/src/Infrastructure/Connector/Action/ProductCrossSelling/DeleteAssignedProductsAction.php
+++ b/src/Infrastructure/Connector/Action/ProductCrossSelling/DeleteAssignedProductsAction.php
@@ -15,7 +15,7 @@ use Symfony\Component\HttpFoundation\Request as HttpRequest;
 
 class DeleteAssignedProductsAction extends AbstractAction
 {
-    private const URI = '/api/v2/product-cross-selling/%s/assigned-products/%s';
+    private const URI = '/api/product-cross-selling/%s/assigned-products/%s';
 
     private string $productCrossSelling;
 

--- a/src/Infrastructure/Connector/Action/ProductCrossSelling/DeleteCrossSellingAction.php
+++ b/src/Infrastructure/Connector/Action/ProductCrossSelling/DeleteCrossSellingAction.php
@@ -15,7 +15,7 @@ use Symfony\Component\HttpFoundation\Request as HttpRequest;
 
 class DeleteCrossSellingAction extends AbstractAction
 {
-    private const URI = '/api/v2/product-cross-selling/%s';
+    private const URI = '/api/product-cross-selling/%s';
 
     private string $productCrossSelling;
 

--- a/src/Infrastructure/Connector/Action/ProductCrossSelling/GetAssignedProductsAction.php
+++ b/src/Infrastructure/Connector/Action/ProductCrossSelling/GetAssignedProductsAction.php
@@ -17,7 +17,7 @@ use Symfony\Component\HttpFoundation\Request as HttpRequest;
 
 class GetAssignedProductsAction extends AbstractAction
 {
-    private const URI = '/api/v2/product-cross-selling/%s/assigned-products';
+    private const URI = '/api/product-cross-selling/%s/assigned-products';
 
     private string $productCrossSelling;
 

--- a/src/Infrastructure/Connector/Action/ProductCrossSelling/GetCrossSellingAction.php
+++ b/src/Infrastructure/Connector/Action/ProductCrossSelling/GetCrossSellingAction.php
@@ -16,7 +16,7 @@ use Symfony\Component\HttpFoundation\Request as HttpRequest;
 
 class GetCrossSellingAction extends AbstractAction
 {
-    private const URI = '/api/v2/product-cross-selling/%s';
+    private const URI = '/api/product-cross-selling/%s';
 
     private string $productCrossSelling;
 

--- a/src/Infrastructure/Connector/Action/ProductCrossSelling/PatchCrossSellingAction.php
+++ b/src/Infrastructure/Connector/Action/ProductCrossSelling/PatchCrossSellingAction.php
@@ -16,7 +16,7 @@ use Symfony\Component\HttpFoundation\Request as HttpRequest;
 
 class PatchCrossSellingAction extends AbstractAction
 {
-    private const URI = '/api/v2/product-cross-selling/%s';
+    private const URI = '/api/product-cross-selling/%s';
 
     private AbstractProductCrossSelling $productCrossSelling;
 

--- a/src/Infrastructure/Connector/Action/ProductCrossSelling/PostCrossSellingAction.php
+++ b/src/Infrastructure/Connector/Action/ProductCrossSelling/PostCrossSellingAction.php
@@ -17,7 +17,7 @@ use Symfony\Component\HttpFoundation\Request as HttpRequest;
 
 class PostCrossSellingAction extends AbstractAction
 {
-    private const URI = '/api/v2/product-cross-selling?%s';
+    private const URI = '/api/product-cross-selling?%s';
 
     private AbstractProductCrossSelling $productCrossSelling;
 

--- a/src/Infrastructure/Connector/Action/PropertyGroup/GetPropertyGroup.php
+++ b/src/Infrastructure/Connector/Action/PropertyGroup/GetPropertyGroup.php
@@ -16,7 +16,7 @@ use Symfony\Component\HttpFoundation\Request as HttpRequest;
 
 class GetPropertyGroup extends AbstractAction
 {
-    private const URI = '/api/v2/property-group/%s';
+    private const URI = '/api/property-group/%s';
 
     private string $propertyGroupId;
 

--- a/src/Infrastructure/Connector/Action/PropertyGroup/GetPropertyGroupList.php
+++ b/src/Infrastructure/Connector/Action/PropertyGroup/GetPropertyGroupList.php
@@ -17,7 +17,7 @@ use Symfony\Component\HttpFoundation\Request as HttpRequest;
 
 class GetPropertyGroupList extends AbstractAction
 {
-    private const URI = '/api/v2/property-group?%s';
+    private const URI = '/api/property-group?%s';
 
     private Shopware6QueryBuilder $query;
 

--- a/src/Infrastructure/Connector/Action/PropertyGroup/GetPropertyGroupOptions.php
+++ b/src/Infrastructure/Connector/Action/PropertyGroup/GetPropertyGroupOptions.php
@@ -16,7 +16,7 @@ use Symfony\Component\HttpFoundation\Request as HttpRequest;
 
 class GetPropertyGroupOptions extends AbstractAction
 {
-    private const URI = '/api/v2/property-group/%s/options/%s';
+    private const URI = '/api/property-group/%s/options/%s';
 
     private string $propertyGroupId;
 

--- a/src/Infrastructure/Connector/Action/PropertyGroup/GetPropertyGroupOptionsList.php
+++ b/src/Infrastructure/Connector/Action/PropertyGroup/GetPropertyGroupOptionsList.php
@@ -16,7 +16,7 @@ use Symfony\Component\HttpFoundation\Request as HttpRequest;
 
 class GetPropertyGroupOptionsList extends AbstractAction
 {
-    private const URI = '/api/v2/property-group/%s/options?%s';
+    private const URI = '/api/property-group/%s/options?%s';
 
     private string $propertyGroupId;
 

--- a/src/Infrastructure/Connector/Action/PropertyGroup/PatchPropertyGroupAction.php
+++ b/src/Infrastructure/Connector/Action/PropertyGroup/PatchPropertyGroupAction.php
@@ -16,7 +16,7 @@ use Symfony\Component\HttpFoundation\Request as HttpRequest;
 
 class PatchPropertyGroupAction extends AbstractAction
 {
-    private const URI = '/api/v2/property-group/';
+    private const URI = '/api/property-group/';
 
     private Shopware6PropertyGroup $propertyGroup;
 

--- a/src/Infrastructure/Connector/Action/PropertyGroup/PatchPropertyGroupOptionAction.php
+++ b/src/Infrastructure/Connector/Action/PropertyGroup/PatchPropertyGroupOptionAction.php
@@ -16,7 +16,7 @@ use Symfony\Component\HttpFoundation\Request as HttpRequest;
 
 class PatchPropertyGroupOptionAction extends AbstractAction
 {
-    private const URI = '/api/v2/property-group/%s/options/%s';
+    private const URI = '/api/property-group/%s/options/%s';
 
     private string $propertyGroupId;
 

--- a/src/Infrastructure/Connector/Action/PropertyGroup/PostPropertyGroupAction.php
+++ b/src/Infrastructure/Connector/Action/PropertyGroup/PostPropertyGroupAction.php
@@ -16,7 +16,7 @@ use Symfony\Component\HttpFoundation\Request as HttpRequest;
 
 class PostPropertyGroupAction extends AbstractAction
 {
-    private const URI = '/api/v2/property-group?%s';
+    private const URI = '/api/property-group?%s';
 
     private Shopware6PropertyGroup $propertyGroup;
 

--- a/src/Infrastructure/Connector/Action/PropertyGroup/PostPropertyGroupOptionsAction.php
+++ b/src/Infrastructure/Connector/Action/PropertyGroup/PostPropertyGroupOptionsAction.php
@@ -16,7 +16,7 @@ use Symfony\Component\HttpFoundation\Request as HttpRequest;
 
 class PostPropertyGroupOptionsAction extends AbstractAction
 {
-    private const URI = '/api/v2/property-group/%s/options?%s';
+    private const URI = '/api/property-group/%s/options?%s';
 
     private string $propertyGroupId;
 

--- a/src/Infrastructure/Connector/Action/Tax/GetTaxList.php
+++ b/src/Infrastructure/Connector/Action/Tax/GetTaxList.php
@@ -17,7 +17,7 @@ use Symfony\Component\HttpFoundation\Request as HttpRequest;
 
 class GetTaxList extends AbstractAction
 {
-    private const URI = '/api/v2/tax?%s';
+    private const URI = '/api/tax?%s';
 
     private Shopware6QueryBuilder $query;
 

--- a/src/Infrastructure/Connector/Action/Tax/PostTaxCreate.php
+++ b/src/Infrastructure/Connector/Action/Tax/PostTaxCreate.php
@@ -16,7 +16,7 @@ use Symfony\Component\HttpFoundation\Request as HttpRequest;
 
 class PostTaxCreate extends AbstractAction
 {
-    private const URI = '/api/v2/tax';
+    private const URI = '/api/tax';
 
     private Shopware6Tax $tax;
 


### PR DESCRIPTION
Shopware decided to remove the version number from the API routing structure.
Please note: "2020-12-02 - API version removal"
https://github.com/shopware/platform/blob/6.4.0.0/adr/2020-12-02-removing-api-version.md
https://developer.shopware.com/docs/guides/integrations-api/general-concepts/api-versioning